### PR TITLE
sync users/keys from OneLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ module "bastion" {
 | log_expiry_days | Number of days before logs expiration | string | `90` | no |
 | log_glacier_days | Number of days before moving logs to Glacier | string | `60` | no |
 | log_standard_ia_days | Number of days before moving logs to IA Storage | string | `30` | no |
+| onelogin_sync | Enable syncing of ssh keys from OneLogin | bool | false | no |
 | private_ssh_port | Set the SSH port to use between the bastion and private instance | string | `22` | no |
 | public_ssh_port | Set the SSH port to use from desktop to the bastion | string | `22` | no |
 | region |  | string | - | yes |
@@ -91,6 +92,13 @@ module "bastion" {
 |------|-------------|
 | bucket_name |  |
 | elb_ip |  |
+
+## OneLogin Sync
+
+Syncing users from OneLogin supported with onelogin_sync=true with the following requirements:
+1.  SSH Keys stored in a user custom attribute called 'sshPublickey'.
+2.  OneLogin credentials stored in SSM Parameter Store parameters /bastion/onelogin_id and /bastion/onelogin_secret.
+
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ module "bastion" {
 | log_glacier_days | Number of days before moving logs to Glacier | string | `60` | no |
 | log_standard_ia_days | Number of days before moving logs to IA Storage | string | `30` | no |
 | onelogin_sync | Enable syncing of ssh keys from OneLogin | bool | false | no |
+| onelogin_sync_role_ids | When using OneLogin sync, optionally limit to a list of role IDs.  If empty, all active users will be synced. | list(int) | [] | no |
 | private_ssh_port | Set the SSH port to use between the bastion and private instance | string | `22` | no |
 | public_ssh_port | Set the SSH port to use from desktop to the bastion | string | `22` | no |
 | region |  | string | - | yes |
@@ -99,6 +100,7 @@ Syncing users from OneLogin supported with onelogin_sync=true with the following
 1.  SSH Keys stored in a user custom attribute called 'sshPublickey'.
 2.  OneLogin credentials with Read perms stored in SSM Parameter Store parameters /bastion/onelogin_id and /bastion/onelogin_secret.
 
+You can optionally limit syncing to users that have a role matching one or more role IDs.
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module "bastion" {
 
 Syncing users from OneLogin supported with onelogin_sync=true with the following requirements:
 1.  SSH Keys stored in a user custom attribute called 'sshPublickey'.
-2.  OneLogin credentials stored in SSM Parameter Store parameters /bastion/onelogin_id and /bastion/onelogin_secret.
+2.  OneLogin credentials with Read perms stored in SSM Parameter Store parameters /bastion/onelogin_id and /bastion/onelogin_secret.
 
 
 Known issues

--- a/main.tf
+++ b/main.tf
@@ -261,6 +261,7 @@ resource "aws_launch_configuration" "bastion_launch_configuration" {
     bucket_name = var.bucket_name
     ssh_tunnel_only_users = var.ssh_tunnel_only_users
     onelogin_sync = var.onelogin_sync
+    onelogin_sync_role_ids = var.onelogin_sync_role_ids
     onelogin_sync_script = file("${path.module}/onelogin_sync/onelogin_sync.py")
     onelogin_sync_requirements = file("${path.module}/onelogin_sync/requirements.txt")
   })

--- a/onelogin_sync/onelogin_sync.py
+++ b/onelogin_sync/onelogin_sync.py
@@ -1,0 +1,93 @@
+#! /usr/bin/python3
+
+import os
+import sys
+import logging
+import re
+import configargparse
+import boto3
+
+from onelogin.api.client import OneLoginClient
+
+
+def get_opts(log):
+    parser = configargparse.ArgParser(default_config_files=['onelogin_lookup.ini'])
+    parser.add('-v', '--verbosity', help='Logging level. Default ERROR', default='error')
+    parser.add('-c', '--config', help='Config file')
+
+    opts = parser.parse_args()
+
+    if opts.verbosity.lower() == 'debug':
+        log.setLevel(logging.DEBUG)
+    elif opts.verbosity.lower() == 'info':
+        log.setLevel(logging.INFO)
+    elif opts.verbosity.lower() == 'warning':
+        log.setLevel(logging.WARNING)
+    elif opts.verbosity.lower() == 'error':
+        log.setLevel(logging.ERROR)
+    elif opts.verbosity.lower() == 'critical':
+        log.setLevel(logging.CRITICAL)
+    return opts
+
+
+def get_logger():
+    logging.basicConfig(format = '%(asctime)s %(levelname)-8s %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
+    log = logging.getLogger('default')
+    return log
+
+
+def setup():
+    log = get_logger()
+    opts = get_opts(log)
+    return opts, log
+
+
+def get_onelogin_credentials():
+    ssm = boto3.client('ssm')
+    parameter = ssm.get_parameter(Name='/bastion/onelogin_id', WithDecryption=True)
+    key_id = parameter['Parameter']['Value']
+    parameter = ssm.get_parameter(Name='/bastion/onelogin_secret', WithDecryption=True)
+    key_secret = parameter['Parameter']['Value']
+    return key_id, key_secret
+
+
+def get_user_list(key_id, key_secret, log):
+    try:
+        onelogin_client = OneLoginClient(
+            key_id,
+            key_secret,
+            "us"
+        )
+    except Exception as onelogin_exception:
+        log.error(onelogin_exception)
+        sys.exit(1)
+
+    onelogin_users = onelogin_client.get_users()
+
+    return onelogin_users
+
+
+def create_delete_users(log, users=None):
+    for u in users:
+
+        if not re.match('^[a-z][-a-z0-9]*$', u.username):
+            log.warning('Skipping invalid username %s' % u.username)
+            continue
+
+        if u.status in [1, 3, 4] and u.state == 1:
+            if 'sshPublickey' in u.custom_attributes and str(u.custom_attributes['sshPublickey'])[0:3] == 'ssh':
+                ssh_public_key = u.custom_attributes['sshPublickey']
+                os.system(f'/usr/bin/id -u {u.username} > /dev/null 2>&1 || /usr/sbin/useradd {u.username}')
+                os.system(f'[ -d "/home/{u.username}/.ssh" ] ||  mkdir "/home/{u.username}/.ssh"')
+                os.system(f'echo {ssh_public_key} > "/home/{u.username}/.ssh/authorized_keys"')
+                os.system(f'/usr/bin/chown -R {u.username}:{u.username} "/home/{u.username}/.ssh"')
+        else:
+            os.system(f'/usr/bin/id -u {u.username} > /dev/null 2>&1 && /usr/sbin/userdel {u.username}')
+
+
+if __name__ == '__main__':
+    (opts, log) = setup()
+    (onelogin_id, onelogin_secret) = get_onelogin_credentials()
+    user_list = get_user_list(key_id=onelogin_id, key_secret=onelogin_secret, log=log)
+    create_delete_users(log=log, users=user_list)

--- a/onelogin_sync/onelogin_sync.py
+++ b/onelogin_sync/onelogin_sync.py
@@ -69,6 +69,7 @@ def get_user_list(key_id, key_secret, log):
 
 
 def create_delete_users(log, users=None):
+    os.environ['PATH'] += os.pathsep + '/usr/sbin'
     for u in users:
 
         if not re.match('^[a-z][-a-z0-9]*$', u.username):
@@ -78,12 +79,12 @@ def create_delete_users(log, users=None):
         if u.status in [1, 3, 4] and u.state == 1:
             if 'sshPublickey' in u.custom_attributes and str(u.custom_attributes['sshPublickey'])[0:3] == 'ssh':
                 ssh_public_key = u.custom_attributes['sshPublickey']
-                os.system(f'/usr/bin/id -u {u.username} > /dev/null 2>&1 || /usr/sbin/useradd {u.username}')
+                os.system(f'id -u {u.username} > /dev/null 2>&1 || useradd -m {u.username}')
                 os.system(f'[ -d "/home/{u.username}/.ssh" ] ||  mkdir "/home/{u.username}/.ssh"')
                 os.system(f'echo {ssh_public_key} > "/home/{u.username}/.ssh/authorized_keys"')
-                os.system(f'/usr/bin/chown -R {u.username}:{u.username} "/home/{u.username}/.ssh"')
+                os.system(f'chown -R {u.username}:{u.username} "/home/{u.username}/.ssh"')
         else:
-            os.system(f'/usr/bin/id -u {u.username} > /dev/null 2>&1 && /usr/sbin/userdel {u.username}')
+            os.system(f'id -u {u.username} > /dev/null 2>&1 && userdel {u.username}')
 
 
 if __name__ == '__main__':

--- a/onelogin_sync/onelogin_sync.py
+++ b/onelogin_sync/onelogin_sync.py
@@ -82,7 +82,10 @@ def create_delete_users(log, users=None):
                 os.system(f'id -u {u.username} > /dev/null 2>&1 || useradd -m {u.username}')
                 os.system(f'[ -d "/home/{u.username}/.ssh" ] ||  mkdir "/home/{u.username}/.ssh"')
                 os.system(f'echo {ssh_public_key} > "/home/{u.username}/.ssh/authorized_keys"')
-                os.system(f'chown -R {u.username}:{u.username} "/home/{u.username}/.ssh"')
+                os.system(f'chown {u.username}:{u.username} "/home/{u.username}/.ssh"')
+            else:
+                os.system(
+                    f'[ -f "/home/{u.username}/.ssh/authorized_keys" ] && rm "/home/{u.username}/.ssh/authorized_keys"')
         else:
             os.system(f'id -u {u.username} > /dev/null 2>&1 && userdel {u.username}')
 

--- a/onelogin_sync/requirements.txt
+++ b/onelogin_sync/requirements.txt
@@ -1,0 +1,4 @@
+ConfigArgParse==0.13.0
+docutils==0.14
+onelogin==1.8.1
+boto3==1.9.201

--- a/user_data.sh
+++ b/user_data.sh
@@ -198,3 +198,25 @@ cat > ~/mycron << EOF
 EOF
 crontab ~/mycron
 rm ~/mycron
+
+%{ if onelogin_sync }
+
+cat > /usr/bin/bastion/onelogin_sync.py << 'EOF'
+${onelogin_sync_script}
+EOF
+
+cat > /usr/bin/bastion/onelogin_sync.requirements << 'EOF'
+${onelogin_sync_requirements}
+EOF
+
+chmod 755 /usr/bin/bastion/onelogin_sync.py
+yum -y install python3
+apt-get -yq install python3
+pip3 install -r /usr/bin/bastion/onelogin_sync.requirements
+
+crontab -l > ~/mycron
+cat >> ~/mycron << EOF
+*/5 * * * * AWS_DEFAULT_REGION=${aws_region} /usr/bin/bastion/onelogin_sync.py
+EOF
+crontab ~/mycron
+%{ endif ~}

--- a/user_data.sh
+++ b/user_data.sh
@@ -199,6 +199,11 @@ EOF
 crontab ~/mycron
 rm ~/mycron
 
+
+###########################################
+## ONELOGIN SYNC                         ##
+###########################################
+
 %{ if onelogin_sync }
 
 cat > /usr/bin/bastion/onelogin_sync.py << 'EOF'
@@ -215,7 +220,8 @@ pip3 install -r /usr/bin/bastion/onelogin_sync.requirements
 
 crontab -l > ~/mycron
 cat >> ~/mycron << EOF
-*/5 * * * * AWS_DEFAULT_REGION=${aws_region} /usr/bin/bastion/onelogin_sync.py
+*/5 * * * * AWS_DEFAULT_REGION=${aws_region} /usr/bin/bastion/onelogin_sync.py %{ for role in onelogin_sync_role_ids ~} --role_id ${role} %{ endfor }
 EOF
 crontab ~/mycron
+rm ~/mycron
 %{ endif ~}

--- a/user_data.sh
+++ b/user_data.sh
@@ -38,7 +38,7 @@ mkdir /usr/bin/bastion
 cat > /usr/bin/bastion/shell << 'EOF'
 
 # Check that the SSH client did not supply a command
-if [[ -z $SSH_ORIGINAL_COMMAND ]]; then
+if [ -z $SSH_ORIGINAL_COMMAND ]; then
 
   # The format of log files is /var/log/bastion/YYYY-MM-DD_HH-MM-SS_user
   LOG_FILE="`date --date="today" "+%Y-%m-%d_%H-%M-%S"`_`whoami`"
@@ -210,8 +210,7 @@ ${onelogin_sync_requirements}
 EOF
 
 chmod 755 /usr/bin/bastion/onelogin_sync.py
-yum -y install python3
-apt-get -yq install python3
+yum -yq install python3 || (apt-get -q update && apt-get -yq install python3-pip)
 pip3 install -r /usr/bin/bastion/onelogin_sync.requirements
 
 crontab -l > ~/mycron

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,7 @@ variable "onelogin_sync" {
   description = "Support syncing users/keys from OneLogin"
   default = false
 }
+
+variable "onelogin_sync_role_ids" {
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,8 @@ variable "static_ssh_users" {
   type = list(map(string))
   default = []
 }
+
+variable "onelogin_sync" {
+  description = "Support syncing users/keys from OneLogin"
+  default = false
+}


### PR DESCRIPTION
This PR allows the bastion to sync its users from OneLogin.

Notes:
- OneLogin credentials are sourced from encrypted keys in SSM Parameter store.  Accessed via EC2 instance profile.  Credentials are read-only, but worth considering if there are any security concerns with the bastion (and anyone with a shell on it) being able to access them albeit hopefully in a fully audit-able environment.
- Optionally allows filtering on a list of role IDs
- Deletes OL non-active users

