### PR TITLE
block public s3 access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,15 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge(var.tags)
 }
 
+resource "aws_s3_bucket_public_access_block" "block" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"


### PR DESCRIPTION
While the bastion's s3 bucket does not have ACLs or policies that would allow public access, let's add a block as a belt-and-suspenders since this should never need to be public.