### PR TITLE
share ssh public keys via https

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@ output "bastion_host_security_group" {
 output "private_instances_security_group" {
   value = "${aws_security_group.private_instances_security_group.id}"
 }
+
+output "aws_share_keys_web_server_lb" {
+  value = var.share_keys_web_server ? aws_lb.share_keys_web_server_lb[0].dns_name : ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -134,5 +134,26 @@ variable "onelogin_sync" {
 }
 
 variable "onelogin_sync_role_ids" {
+  description = "Numeric OneLogin role IDs to include in sync.  If none specified sync all avtive users with keys."
+  default = []
+}
+
+variable "share_keys_web_server" {
+  description = "Share public keys via a web server"
+  default = false
+}
+
+variable "share_keys_elb_subnets" {
+  description = "Share public keys via a web server"
+  default = []
+}
+
+variable "share_keys_allowed_cidrs" {
+  description = "CIDRs allowed to web get authorized keys"
+  default = []
+}
+
+variable "share_keys_allowed_sec_groups" {
+  description = "Security groups allowed to web get authorized keys"
   default = []
 }


### PR DESCRIPTION
Once a user is SSHed to the bastion, they may want to ssh to other hosts.  This option allows those
other hosts to use the same keys that are in use on the bastion by sharing those keys via HTTPS.

Notes: 
1.  Key sharing currently only supports HTTPS using a self-signed key.
2.  All keys for all bastion users are shared in one concatenated response.  So this is appropriate for next-hop/targets
with a shared user account (e.g. "ec2-user" or "ubuntu") rather than instances with multiple users with distinct access
control policies.


Example bastion Terraform configuration:
```
module "bastion" {
...
  share_keys_web_server = true
  share_keys_elb_subnets = module.vpc.private_subnets
  share_keys_allowed_cidrs = [ "10.0.0.0/8" ]
}
```

Example target instance Terraform configuration:
```
data "aws_lb" "authorized_keys" {
  name = "ssh-bastion-authorized-keys"
}

resource "aws_instance" "test" {
  ...
  user_data = <<EOF
#!/bin/bash -xe
echo AuthorizedKeysCommand /usr/bin/timeout 5 /usr/bin/curl --insecure https://${data.aws_lb.authorized_keys.dns_name}/authorized_keys >> /etc/ssh/sshd_config
echo AuthorizedKeysCommandUser nobody >> /etc/ssh/sshd_config
systemctl restart sshd.service
EOF
}
```

To make use of key sharing, use ssh agent forwarding:
```
workstation $ ssh -A <bastion-username>@bastion-lb.example.com
...
<bastion-username>@bastion $ ssh <target-username>@target.example.com
...
<target--username>@target $
```
